### PR TITLE
Add Airtable authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.streamlit/secrets.toml
+.env
+rsvps.csv

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,4 +1,9 @@
-[AIRTABLE]
-api_key    = "YOUR_AIRTABLE_API_KEY"
-base_id    = "appXXXXXXXXXXXXXX"
-table_name = "Codes"
+[connections.gsheets]
+# Google service account credentials
+# For more details see Streamlit docs
+spreadsheet = "https://docs.google.com/spreadsheets/d/your-sheet-id"
+worksheet = "Codes"
+# type = "service_account"
+# project_id = "YOUR_PROJECT_ID"
+# private_key = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+# client_email = "your-service-account@your-project.iam.gserviceaccount.com"

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,4 @@
+[AIRTABLE]
+api_key    = "YOUR_AIRTABLE_API_KEY"
+base_id    = "appXXXXXXXXXXXXXX"
+table_name = "Codes"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Streamlit Airtable Auth
+
+This app is a wedding invitation built with Streamlit. An access code is validated against an Airtable table before the invitation is shown.
+
+## Setup
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.streamlit/secrets.toml.example` to `.streamlit/secrets.toml` and fill in your Airtable credentials.
+
+## Running locally
+```
+streamlit run app.py
+```
+
+## Deploying
+Deploy on Streamlit Community Cloud and set the same secrets in the UI.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Streamlit Airtable Auth
+# Streamlit Google Sheets Auth
 
-This app is a wedding invitation built with Streamlit. An access code is validated against an Airtable table before the invitation is shown.
+This app is a wedding invitation built with Streamlit. An access code is validated against a Google Sheet using Streamlit's `GSheetsConnection`.
 
 ## Setup
 1. Install Python dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. Copy `.streamlit/secrets.toml.example` to `.streamlit/secrets.toml` and fill in your Airtable credentials.
+2. Copy `.streamlit/secrets.toml.example` to `.streamlit/secrets.toml` and fill in your Google service account credentials and sheet details.
 
 ## Running locally
 ```
@@ -16,3 +16,15 @@ streamlit run app.py
 
 ## Deploying
 Deploy on Streamlit Community Cloud and set the same secrets in the UI.
+
+### Secrets format
+
+```
+[connections.gsheets]
+spreadsheet = "https://docs.google.com/spreadsheets/d/YOUR_ID"
+worksheet = "Codes"
+# type = "service_account"
+# project_id = "YOUR_PROJECT_ID"
+# private_key = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+# client_email = "your-service-account@your-project.iam.gserviceaccount.com"
+```

--- a/app.py
+++ b/app.py
@@ -3,8 +3,7 @@ import pandas as pd
 import os
 import base64
 import datetime
-from pydantic import BaseModel
-from airtable import Airtable
+from streamlit_gsheets import GSheetsConnection
 
 # --- Page Configuration ---
 st.set_page_config(
@@ -16,25 +15,21 @@ st.set_page_config(
 # --- File for RSVPs ---
 RSVP_FILE = "rsvps.csv"
 
-# --- Airtable Configuration ---
-AT = st.secrets.get("AIRTABLE", {})
-airtable = Airtable(AT.get("base_id", ""), AT.get("table_name", ""), api_key=AT.get("api_key", ""))
-
-# --- Validation Model and Function ---
-class CodeRequest(BaseModel):
-    code: str
+# --- Google Sheets Connection ---
+conn = st.experimental_connection("gsheets", type=GSheetsConnection)
 
 def validate_code(code: str):
-    recs = airtable.search("Code", code)
-    if not recs:
+    df = conn.read(worksheet="Codes")
+    recs = df[df["Code"] == code]
+    if recs.empty:
         raise ValueError("Invalid code")
-    f = recs[0]["fields"]
-    name = f.get("NameAsso") or f.get("Name")
-    raw = f.get("Status")
+    row = recs.iloc[0]
+    name = row.get("NameAsso") or row.get("Name")
+    raw = row.get("Status")
     if isinstance(raw, bool):
         status = "yes" if raw else "no"
     else:
-        status = (raw or "no").lower()
+        status = str(raw or "no").lower()
     return name, status
 
 # --- Function to get base64 encoded image for CSS ---

--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ import pandas as pd
 import os
 import base64
 import datetime
+from pydantic import BaseModel
+from airtable import Airtable
 
 # --- Page Configuration ---
 st.set_page_config(
@@ -13,6 +15,27 @@ st.set_page_config(
 
 # --- File for RSVPs ---
 RSVP_FILE = "rsvps.csv"
+
+# --- Airtable Configuration ---
+AT = st.secrets.get("AIRTABLE", {})
+airtable = Airtable(AT.get("base_id", ""), AT.get("table_name", ""), api_key=AT.get("api_key", ""))
+
+# --- Validation Model and Function ---
+class CodeRequest(BaseModel):
+    code: str
+
+def validate_code(code: str):
+    recs = airtable.search("Code", code)
+    if not recs:
+        raise ValueError("Invalid code")
+    f = recs[0]["fields"]
+    name = f.get("NameAsso") or f.get("Name")
+    raw = f.get("Status")
+    if isinstance(raw, bool):
+        status = "yes" if raw else "no"
+    else:
+        status = (raw or "no").lower()
+    return name, status
 
 # --- Function to get base64 encoded image for CSS ---
 def get_base64_of_bin_file(bin_file):
@@ -304,12 +327,31 @@ def show_landing_page():
         st.session_state.landing_done = True
         st.rerun()
 
+# --- Login Logic ---
+def login():
+    st.title("\U0001F512 Enter Access Code")
+    code = st.text_input("Code", key="login_code")
+    if st.button("Submit"):
+        try:
+            st.session_state.name, st.session_state.status = validate_code(code)
+            st.session_state.authenticated = True
+            st.experimental_rerun()
+        except Exception:
+            st.error("\u274C Invalid code")
+
 # --- Main App Routing ---
 if "landing_done" not in st.session_state:
     st.session_state.landing_done = False
 
 if not st.session_state.landing_done:
     show_landing_page()
+    st.stop()
+
+if "authenticated" not in st.session_state:
+    st.session_state.authenticated = False
+
+if not st.session_state.authenticated:
+    login()
     st.stop()
 
 # --- Main App Logic ---
@@ -335,6 +377,8 @@ lang_choice = st.sidebar.radio("Language / Тіл", ["Русский", "Қаза
 lang = "ru" if lang_choice == "Русский" else "kz"
 
 t = content[lang]
+
+st.success(f"Welcome, {st.session_state.get('name','Guest')}! Status: {st.session_state.get('status','').upper()}")
 
 # --- Display Invitation Details ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ streamlit
 pandas
 gspread
 oauth2client
+pydantic
+airtable-python-wrapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ streamlit
 pandas
 gspread
 oauth2client
-pydantic
-airtable-python-wrapper
+st-gsheets-connection


### PR DESCRIPTION
## Summary
- add repo metadata and secrets example
- require Airtable and Pydantic packages
- integrate Airtable code validation and login gating in `app.py`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `streamlit run app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_687039aa223c83238a57da46cccdc9e7